### PR TITLE
Use UUIDs for document IDs in insert_documents method

### DIFF
--- a/app/load_data.py
+++ b/app/load_data.py
@@ -1,65 +1,60 @@
-# app/load_data.py
 import json
 import os
 import uuid
 from glob import glob
 from app.llm_client import LlamaEdgeClient
 from app.vector_store import QdrantStore
+import logging
+
+PROJECT_COLLECTION = "project_examples"
+ERROR_COLLECTION = "error_examples"
+PROJECT_DATA_PATH = "data/project_examples/*.json"
+ERROR_DATA_PATH = "data/error_examples/*.json"
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def load_examples(vector_store, llm_client, collection_name, file_pattern, text_key):
+    """Load examples into vector database"""
+    # Ensure collections exist
+    vector_store.create_collection(collection_name)
+    
+    example_files = glob(file_pattern)
+    
+    # Collect all embeddings and metadata first
+    embeddings = []
+    metadata = []
+    
+    for file_path in example_files:
+        with open(file_path, 'r') as f:
+            example = json.load(f)
+        
+        # Get embedding for query or error
+        try:
+            embedding = llm_client.get_embeddings([example[text_key]])[0]
+            embeddings.append(embedding)
+            metadata.append(example)
+            logger.info(f"Loaded {collection_name[:-1]} example: {example[text_key][:50]}...")
+        except Exception as e:
+            logger.error(f"Error loading {file_path}: {e}")
+    
+    # Insert all documents in a single batch
+    if embeddings:
+        vector_store.insert_documents(collection_name, embeddings, metadata)
 
 def load_project_examples():
     """Load project examples into vector database"""
     vector_store = QdrantStore()
     llm_client = LlamaEdgeClient()
     
-    # Ensure collections exist
-    vector_store.create_collection("project_examples")
-    
-    example_files = glob("data/project_examples/*.json")
-    
-    for file_path in example_files:
-        with open(file_path, 'r') as f:
-            example = json.load(f)
-        
-        # Get embedding for query
-        embedding = llm_client.get_embeddings([example["query"]])[0]
-        
-        # Store in vector DB with proper UUID
-        point_id = str(uuid.uuid4())  # Generate proper UUID
-        
-        vector_store.upsert("project_examples", 
-                          [{"id": point_id,  # Use UUID instead of filename
-                            "vector": embedding, 
-                            "payload": example}])
-        
-        print(f"Loaded project example: {example['query']}")
+    load_examples(vector_store, llm_client, PROJECT_COLLECTION, PROJECT_DATA_PATH, "query")
 
 def load_error_examples():
     """Load compiler error examples into vector database"""
     vector_store = QdrantStore()
     llm_client = LlamaEdgeClient()
     
-    # Ensure collections exist
-    vector_store.create_collection("error_examples")
-    
-    error_files = glob("data/error_examples/*.json")
-    
-    for file_path in error_files:
-        with open(file_path, 'r') as f:
-            example = json.load(f)
-        
-        # Get embedding for error
-        embedding = llm_client.get_embeddings([example["error"]])[0]
-
-        # Store in vector DB with proper UUID
-        point_id = str(uuid.uuid4())
-        
-        # Store in vector DB
-        vector_store.upsert("error_examples", 
-                           [{"id": point_id, 
-                             "vector": embedding, 
-                             "payload": example}])
-        
-        print(f"Loaded error example: {example['error'][:50]}...")
+    load_examples(vector_store, llm_client, ERROR_COLLECTION, ERROR_DATA_PATH, "error")
 
 if __name__ == "__main__":
     load_project_examples()

--- a/app/vector_store.py
+++ b/app/vector_store.py
@@ -4,6 +4,9 @@ from typing import Dict, List, Optional, Any
 from qdrant_client import QdrantClient
 from qdrant_client.http import models as qmodels
 from qdrant_client import models  # Add this import
+from glob import glob
+import json
+from app.llm_client import LlamaEdgeClient  # Adjust the import based on your project structure
 
 class QdrantStore:
     """Interface for Qdrant vector database"""
@@ -122,3 +125,32 @@ class QdrantStore:
         except Exception as e:
             print(f"Error getting count for collection {collection_name}: {e}")
             return 0
+
+def load_project_examples():
+    """Load project examples into vector database"""
+    vector_store = QdrantStore()
+    llm_client = LlamaEdgeClient()
+    
+    # Ensure collections exist
+    vector_store.create_collection("project_examples")
+    
+    example_files = glob("data/project_examples/*.json")
+    
+    embeddings = []
+    metadata = []
+    
+    for file_path in example_files:
+        with open(file_path, 'r') as f:
+            example = json.load(f)
+        
+        # Get embedding for query
+        embedding = llm_client.get_embeddings([example["query"]])[0]
+        
+        embeddings.append(embedding)
+        metadata.append(example)
+        
+        print(f"Loaded project example: {example['query']}")
+    
+    # Insert all documents in a single batch
+    if embeddings:
+        vector_store.insert_documents("project_examples", embeddings, metadata)

--- a/app/vector_store.py
+++ b/app/vector_store.py
@@ -55,9 +55,9 @@ class QdrantStore:
                         metadata: List[Dict[str, Any]]):
         """Insert documents with embeddings and metadata into collection"""
         points = []
-        for i, (embedding, meta) in enumerate(zip(embeddings, metadata)):
+        for embedding, meta in zip(embeddings, metadata):
             points.append(models.PointStruct(
-                id=i,
+                id=str(uuid.uuid4()),  # Using UUID instead of index
                 vector=embedding,
                 payload=meta
             ))


### PR DESCRIPTION
**One thing to be aware of:** this change will affect any existing data in your Qdrant store. If we already have vectors in your collections that were inserted with sequential IDs, and we now start inserting with UUIDs, we'll have a mix of ID formats. This won't cause errors but might be confusing when examining the data directly. If we need to work with existing data and maintain consistency, we might want to:
Create new collections Re-index all your data with UUIDs Switch to the new collections when complete.